### PR TITLE
fix: remove newline characters in base64 encoding command in README

### DIFF
--- a/applications/golang-langchain-demo/README.md
+++ b/applications/golang-langchain-demo/README.md
@@ -15,7 +15,7 @@
    export OTEL_EXPORTER_OTLP_ENDPOINT="https://cloud.langfuse.com/api/public/otel" # 🇪🇺 EU data region
    # export OTEL_EXPORTER_OTLP_ENDPOINT="https://us.cloud.langfuse.com/api/public/otel" # 🇺🇸 US data region
    # export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:3000/api/public/otel" # 🏠 Local deployment (>= v3.22.0)
-   export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic $(echo -n "pk-lf-xxx:sk-lf-xxx" | base64)"
+   export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic $(echo -n "pk-lf-xxx:sk-lf-xxx" | base64 | tr -d '\n')"
    ```
    
 2. Provision dependencies:

--- a/applications/quarkus-langchain4j-demo/README.md
+++ b/applications/quarkus-langchain4j-demo/README.md
@@ -15,7 +15,7 @@
    export QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT="https://cloud.langfuse.com/api/public/otel" # 🇪🇺 EU data region
    # export QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT="https://us.cloud.langfuse.com/api/public/otel" # 🇺🇸 US data region
    # export QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:3000/api/public/otel" # 🏠 Local deployment (>= v3.22.0)
-   export QUARKUS_OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic $(echo -n "pk-lf-xxx:sk-lf-xxx" | base64)"
+   export QUARKUS_OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic $(echo -n "pk-lf-xxx:sk-lf-xxx" | base64 | tr -d '\n')"
    ```
 2. Run the sample application via `./mvnw quarkus:dev`.
 3. Observe the new trace in the Langfuse web UI.

--- a/applications/spring-ai-demo/README.md
+++ b/applications/spring-ai-demo/README.md
@@ -15,7 +15,7 @@
    export OTEL_EXPORTER_OTLP_ENDPOINT="https://cloud.langfuse.com/api/public/otel" # 🇪🇺 EU data region
    # export OTEL_EXPORTER_OTLP_ENDPOINT="https://us.cloud.langfuse.com/api/public/otel" # 🇺🇸 US data region
    # export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:3000/api/public/otel" # 🏠 Local deployment (>= v3.22.0)
-   export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic $(echo -n "pk-lf-xxx:sk-lf-xxx" | base64)"
+   export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic $(echo -n "pk-lf-xxx:sk-lf-xxx" | base64 | tr -d '\n')"
    ```
 2. Run the sample application with `./mvnw clean install spring-boot:run`.
 3. Call the chat endpoint with `curl localhost:8080/v1/chat`.


### PR DESCRIPTION
On Linux/macOS, the base64 command adds a newline character (\n) after every 76 characters by default.
This can cause an Ahthrization header error.Therefore, I used `tr -d '\n'` to filter out the newline character.