### PR TITLE
fix: resolve OpenTelemetry version conflict in Spring AI demo when JDBC datasource is present

### DIFF
--- a/applications/spring-ai-demo/pom.xml
+++ b/applications/spring-ai-demo/pom.xml
@@ -63,9 +63,24 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <!-- Micrometer Observation -> OpenTelemetry bridge -->
+        <!-- Exclude old opentelemetry-instrumentation-api-incubator (2.9.0-alpha) pulled transitively,
+             which conflicts with opentelemetry-jdbc 2.17.0-alpha when JDBC datasource is configured.
+             See: https://github.com/langfuse/langfuse-examples/pull/XXX -->
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-tracing-bridge-otel</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.opentelemetry.instrumentation</groupId>
+                    <artifactId>opentelemetry-instrumentation-api-incubator</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- Explicitly declare 2.17.0-alpha to override the excluded old version -->
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-instrumentation-api-incubator</artifactId>
+            <version>2.17.0-alpha</version>
         </dependency>
         <!-- OpenTelemetry OTLP exporter for traces -->
         <dependency>


### PR DESCRIPTION
## Problem

This demo works as-is, but **any project that adds a JDBC datasource will fail to start** due to a transitive dependency version conflict.

### Steps to reproduce

1. Add to pom.xml:
   ```xml
   <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-jdbc</artifactId>
   </dependency>
   <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
       <scope>runtime</scope>
   </dependency>
   ```
2. Add datasource config to `application.yaml`:
   ```yaml
   spring:
     datasource:
       url: jdbc:postgresql://localhost:5432/test
       username: postgres
       password: postgres
   ```
3. Run `./mvnw spring-boot:run`

### Error output

```
***************************
APPLICATION FAILED TO START
***************************

An attempt was made to call a method that does not exist.

The following method did not exist:
    'setCaptureQueryParameters(boolean)'

The calling class, io.opentelemetry.instrumentation.jdbc.internal.JdbcInstrumenterFactory,
was loaded from: opentelemetry-jdbc-2.17.0-alpha.jar

The called class, SqlClientAttributesExtractorBuilder,
was loaded from: opentelemetry-instrumentation-api-incubator-2.9.0-alpha.jar
```

### Root cause

`micrometer-tracing-bridge-otel` (Spring Boot 3.4.x manages version 1.4.4) has a transitive dependency on `opentelemetry-instrumentation-api-incubator:2.9.0-alpha`.

`opentelemetry-jdbc:2.17.0-alpha` (from `opentelemetry-spring-boot-starter`) requires `opentelemetry-instrumentation-api-incubator:2.17.0-alpha`.

Maven resolves this in favor of the transitive dependency (2.9.0-alpha) because transitive dependencies take precedence over BOM declarations. Reordering BOMs in `dependencyManagement` does not fix this.

## Fix

- Exclude `opentelemetry-instrumentation-api-incubator` from `micrometer-tracing-bridge-otel`
- Explicitly declare `opentelemetry-instrumentation-api-incubator:2.17.0-alpha`

## Test plan

- [ ] Run the demo as-is (no JDBC) — behavior unchanged
- [ ] Add `spring-boot-starter-jdbc` + database driver + `spring.datasource` config — app starts without error
- [ ] Verify LLM call and Langfuse trace export still work correctly